### PR TITLE
Map collections to data types

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -2,9 +2,7 @@ version = "3.7.17"
 runner.dialect = scala3
 maxColumn = 120
 align {
-  preset=some
-  # openParenTupleSite = true
-  # openParenDefnSite = true
+  preset = some
   tokens = ["%", "%%", "<-"]
 }
 indent {
@@ -13,9 +11,3 @@ indent {
   defnSite = 1
   extraBeforeOpenParenDefnSite = 6
 }
-# newlines {
-#   source = unfold
-#   implicitParamListModifierPrefer = after
-#   beforeOpenParenDefnSite = unfold
-#   selectChains = unfold
-# }

--- a/build.sbt
+++ b/build.sbt
@@ -72,4 +72,26 @@ lazy val molly_core = project
       testFrameworks += new TestFramework("weaver.framework.CatsEffect")
    )
 
-lazy val molly = project.in(file(".")).settings(publish / skip := true).aggregate(molly_core)
+lazy val molly_medeia = project
+   .in(file("molly-medeia"))
+   .settings(commonSettings: _*)
+   .settings(
+      name := "molly-medeia",
+      libraryDependencies ++=
+         Seq(
+            "de.megaera"    %% "medeia"             % "0.10.0",
+            "org.mongodb"    % "bson"               % "4.10.2",
+            "org.typelevel" %% "cats-core"          % "2.10.0",
+            "org.typelevel" %% "cats-effect-kernel" % "3.5.2",
+            //
+            "com.dimafeng"        %% "testcontainers-scala-mongodb" % "0.41.0" % Test,
+            "com.disneystreaming" %% "weaver-cats"                  % "0.8.3"  % Test,
+            "org.mongodb"          % "mongodb-driver-core"          % "4.10.2",
+            "org.slf4j"            % "slf4j-simple"                 % "2.0.9"  % Test,
+            "org.typelevel"       %% "cats-effect"                  % "3.5.2"  % Test
+         ),
+      testFrameworks += new TestFramework("weaver.framework.CatsEffect")
+   )
+   .dependsOn(molly_core % "compile->compile;test->test")
+
+lazy val molly = project.in(file(".")).settings(publish / skip := true).aggregate(molly_core, molly_medeia)

--- a/molly-core/src/main/scala/molly/core/MollyCodec.scala
+++ b/molly-core/src/main/scala/molly/core/MollyCodec.scala
@@ -1,0 +1,11 @@
+package molly.core
+
+import cats.effect.kernel.Async
+import org.bson.BsonDocument
+
+/** Interface for mapping a data type A to a collection.
+  */
+abstract class MollyCodec[F[_]: Async, A] {
+   def decode(doc: BsonDocument): F[A]
+   def encode(obj: A): F[BsonDocument]
+}

--- a/molly-core/src/main/scala/molly/core/MollyDatabase.scala
+++ b/molly-core/src/main/scala/molly/core/MollyDatabase.scala
@@ -6,6 +6,8 @@ import cats.syntax.functor.*
 import com.mongodb.reactivestreams.client.MongoDatabase
 import org.bson.BsonDocument
 
+import bsondocument.BsonDocumentCollection
+
 /** Molly's counterpart to
   * [[https://mongodb.github.io/mongo-java-driver/4.10/apidocs/mongodb-driver-reactivestreams/com/mongodb/reactivestreams/client/MongoDatabase.html MongoDatabase]]
   *
@@ -15,12 +17,22 @@ final case class MollyDatabase[F[_]: Async] private[core] (private[core] val del
 
    /** [[https://mongodb.github.io/mongo-java-driver/4.10/apidocs/mongodb-driver-reactivestreams/com/mongodb/reactivestreams/client/MongoDatabase.html#getCollection(java.lang.String)]]
      */
-   def getCollection(collectionName: String): F[MollyCollection[F]] =
+   def getCollection(collectionName: String): F[BsonDocumentCollection[F]] = {
+      import bsondocument.bsonDocumentCodec
       Async[F].delay(delegate.getCollection(collectionName, classOf[BsonDocument])).map(MollyCollection(_))
+   }
 
    /** Like [[this.getCollection]], but returns a
      * [[https://typelevel.org/cats-effect/api/3.x/cats/effect/kernel/Resource.html Resource]]
      */
-   def getCollectionAsResource(collectionName: String): Resource[F, MollyCollection[F]] =
+   def getCollectionAsResource(collectionName: String): Resource[F, BsonDocumentCollection[F]] =
       Resource.eval(getCollection(collectionName))
+
+   def getTypedCollection[A](collectionName: String)(implicit codec: MollyCodec[F, A]): F[MollyCollection[F, A]] =
+      Async[F].delay(delegate.getCollection(collectionName, classOf[BsonDocument])).map(MollyCollection[F, A](_))
+
+   def getTypedCollectionAsResource[A](collectionName: String)(implicit
+    codec: MollyCodec[F, A]
+   ): Resource[F, MollyCollection[F, A]] =
+      Resource.eval(getTypedCollection(collectionName))
 }

--- a/molly-core/src/main/scala/molly/core/bsondocument.scala
+++ b/molly-core/src/main/scala/molly/core/bsondocument.scala
@@ -1,0 +1,16 @@
+package molly.core
+
+import cats.effect.kernel.Async
+import org.bson.BsonDocument
+
+/** An implementation of [[molly.core.MollyCodec]] for [[org.bson.BsonDocument]] (identity mapping).
+  */
+object bsondocument {
+
+   implicit def bsonDocumentCodec[F[_]: Async]: MollyCodec[F, BsonDocument] = new MollyCodec[F, BsonDocument] {
+      override def decode(doc: BsonDocument): F[BsonDocument] = Async[F].pure(doc)
+      override def encode(obj: BsonDocument): F[BsonDocument] = Async[F].pure(obj)
+   }
+
+   type BsonDocumentCollection[F[_]] = MollyCollection[F, BsonDocument]
+}

--- a/molly-core/src/main/scala/molly/core/query/AggregateQuery.scala
+++ b/molly-core/src/main/scala/molly/core/query/AggregateQuery.scala
@@ -13,7 +13,7 @@ final case class AggregateQuery[F[_]: Async] private[core] (
 
    def first: F[Option[BsonDocument]] = fromOptionPublisher(publisher.first)
 
-   def list: F[List[BsonDocument]] = stream.compile.toList
+   def list(bufferSize: Int = 16): F[List[BsonDocument]] = stream(bufferSize).compile.toList
 
-   def stream: Stream[F, BsonDocument] = fromStreamPublisher(publisher, bufferSize = 1)
+   def stream(bufferSize: Int = 16): Stream[F, BsonDocument] = fromStreamPublisher(publisher, bufferSize)
 }

--- a/molly-core/src/main/scala/molly/core/query/FindQuery.scala
+++ b/molly-core/src/main/scala/molly/core/query/FindQuery.scala
@@ -1,22 +1,33 @@
 package molly.core.query
 
 import cats.effect.kernel.Async
+import cats.syntax.flatMap.*
+import cats.syntax.functor.*
+import cats.syntax.traverse.*
 import com.mongodb.reactivestreams.client.FindPublisher
 import fs2.Stream
+import molly.core.MollyCodec
 import molly.core.reactivestreams.fromOptionPublisher
 import molly.core.reactivestreams.fromStreamPublisher
 import org.bson.BsonDocument
 import org.bson.conversions.Bson
 
-final case class FindQuery[F[_]: Async] private[core] (private[core] val publisher: FindPublisher[BsonDocument]) {
+final case class FindQuery[F[_], A] private[core] (private[core] val publisher: FindPublisher[BsonDocument])(implicit
+ f: Async[F],
+ codec: MollyCodec[F, A]
+) {
 
-   def filter(filter: Bson): FindQuery[F] = FindQuery(publisher.filter(filter))
+   def filter(filter: Bson): FindQuery[F, A] = FindQuery(publisher.filter(filter))
 
-   def limit(limit: Int): FindQuery[F] = FindQuery(publisher.limit(limit))
+   def limit(limit: Int): FindQuery[F, A] = FindQuery(publisher.limit(limit))
 
-   def first: F[Option[BsonDocument]] = fromOptionPublisher(publisher.first)
+   def first: F[Option[A]] =
+      for {
+         resultDoc <- fromOptionPublisher(publisher.first)
+         result    <- resultDoc.traverse(codec.decode)
+      } yield result
 
-   def list: F[List[BsonDocument]] = stream.compile.toList
+   def list(bufferSize: Int = 16): F[List[A]] = stream(bufferSize).compile.toList
 
-   def stream: Stream[F, BsonDocument] = fromStreamPublisher(publisher, bufferSize = 1)
+   def stream(bufferSize: Int = 16): Stream[F, A] = fromStreamPublisher(publisher, bufferSize).evalMap(codec.decode)
 }

--- a/molly-core/src/main/scala/molly/core/query/WatchQuery.scala
+++ b/molly-core/src/main/scala/molly/core/query/WatchQuery.scala
@@ -1,30 +1,58 @@
 package molly.core.query
 
 import cats.effect.kernel.Async
+import cats.syntax.flatMap.*
+import cats.syntax.functor.*
+import cats.syntax.traverse.*
 import com.mongodb.client.model.changestream.ChangeStreamDocument
 import com.mongodb.client.model.changestream.FullDocument
 import com.mongodb.reactivestreams.client.ChangeStreamPublisher
 import fs2.Stream
+import molly.core.MollyCodec
 import molly.core.reactivestreams.fromStreamPublisher
 import org.bson.BsonDocument
 
-final case class WatchQuery[F[_]: Async] private[core] (
+final case class WatchQuery[F[_], A] private[core] (
  private[core] val publisher: ChangeStreamPublisher[BsonDocument]
+)(implicit
+ f: Async[F],
+ codec: MollyCodec[F, A]
 ) {
 
    /** [[https://mongodb.github.io/mongo-java-driver/4.10/apidocs/mongodb-driver-reactivestreams/com/mongodb/reactivestreams/client/ChangeStreamPublisher.html#resumeAfter(org.bson.BsonDocument)]]
      */
-   def resumeAfter(resumeToken: BsonDocument): WatchQuery[F] = WatchQuery(publisher.resumeAfter(resumeToken))
+   def resumeAfter(resumeToken: BsonDocument): WatchQuery[F, A] = WatchQuery(publisher.resumeAfter(resumeToken))
 
    /** [[https://mongodb.github.io/mongo-java-driver/4.10/apidocs/mongodb-driver-reactivestreams/com/mongodb/reactivestreams/client/ChangeStreamPublisher.html#batchSize(int)]]
      */
-   def batchSize(batchSize: Int): WatchQuery[F] = WatchQuery(publisher.batchSize(batchSize))
+   def batchSize(batchSize: Int): WatchQuery[F, A] = WatchQuery(publisher.batchSize(batchSize))
 
    /** [[https://mongodb.github.io/mongo-java-driver/4.10/apidocs/mongodb-driver-reactivestreams/com/mongodb/reactivestreams/client/ChangeStreamPublisher.html#fullDocument(com.mongodb.client.model.changestream.FullDocument)]]
      */
-   def fullDocument(fullDocument: FullDocument): WatchQuery[F] = WatchQuery(publisher.fullDocument(fullDocument))
+   def fullDocument(fullDocument: FullDocument): WatchQuery[F, A] = WatchQuery(publisher.fullDocument(fullDocument))
 
-   def list: F[List[ChangeStreamDocument[BsonDocument]]] = stream.compile.toList
+   def list(bufferSize: Int = 16): F[List[ChangeStreamDocument[A]]] = stream(bufferSize).compile.toList
 
-   def stream: Stream[F, ChangeStreamDocument[BsonDocument]] = fromStreamPublisher(publisher, bufferSize = 1)
+   def stream(bufferSize: Int = 16): Stream[F, ChangeStreamDocument[A]] =
+      fromStreamPublisher(publisher, bufferSize).evalMap { csd =>
+         for {
+            fd   <- Option(csd.getFullDocument).traverse(codec.decode)
+            fdbc <- Option(csd.getFullDocumentBeforeChange).traverse(codec.decode)
+         } yield new ChangeStreamDocument(
+            csd.getOperationTypeString,
+            csd.getResumeToken,
+            csd.getNamespaceDocument,
+            csd.getDestinationNamespaceDocument,
+            fd.getOrElse(null.asInstanceOf[A]),
+            fdbc.getOrElse(null.asInstanceOf[A]),
+            csd.getDocumentKey,
+            csd.getClusterTime,
+            csd.getUpdateDescription,
+            csd.getTxnNumber,
+            csd.getLsid,
+            csd.getWallTime,
+            csd.getSplitEvent,
+            csd.getExtraElements
+         )
+      }
 }

--- a/molly-core/src/test/scala/molly/core/MollyCollectionTest.scala
+++ b/molly-core/src/test/scala/molly/core/MollyCollectionTest.scala
@@ -8,6 +8,7 @@ import com.mongodb.client.model.Filters
 import com.mongodb.client.model.Indexes
 import com.mongodb.client.model.Projections
 import com.mongodb.client.model.Updates
+import molly.core.bsondocument.BsonDocumentCollection
 import molly.core.model.CreateIndexOptions
 import molly.core.model.DeleteOneModel
 import molly.core.model.FindOneAndReplaceOptions
@@ -34,7 +35,7 @@ object MollyCollectionTest extends IOSuite with TestContainerForAll[IO] with Mol
          for {
             db      <- client.getDatabase("test")
             coll    <- db.getCollection("aggregate1")
-            results <- coll.aggregate(Seq(Aggregates.project(Projections.include("foo", "bar")))).list
+            results <- coll.aggregate(Seq(Aggregates.project(Projections.include("foo", "bar")))).list()
          } yield expect(results.isEmpty)
       }
    }
@@ -57,7 +58,7 @@ object MollyCollectionTest extends IOSuite with TestContainerForAll[IO] with Mol
             db      <- client.getDatabase("test")
             coll    <- db.getCollection("aggregate2")
             _       <- coll.insertMany(Seq(doc1, doc2, doc3))
-            results <- coll.aggregate(Seq(Aggregates.project(Projections.include("foo", "bar")))).list
+            results <- coll.aggregate(Seq(Aggregates.project(Projections.include("foo", "bar")))).list()
          } yield expect(results.size == 3)
             .and(expect(results.forall(_.containsKey("_id"))))
             .and(expect(results.forall(_.containsKey("foo"))))
@@ -76,7 +77,7 @@ object MollyCollectionTest extends IOSuite with TestContainerForAll[IO] with Mol
             db      <- client.getDatabase("test")
             coll    <- db.getCollection("bulkWrite1")
             _       <- coll.bulkWrite(writeCommands)
-            results <- coll.find().list
+            results <- coll.find().list()
          } yield expect(results.size == 3)
             .and(expect(results.contains(doc1)))
             .and(expect(results.contains(doc2)))
@@ -98,7 +99,7 @@ object MollyCollectionTest extends IOSuite with TestContainerForAll[IO] with Mol
             db      <- client.getDatabase("test")
             coll    <- db.getCollection("bulkWrite2")
             _       <- coll.bulkWrite(writeCommands)
-            results <- coll.find().list
+            results <- coll.find().list()
          } yield expect(results.size == 1).and(expect(results.contains(doc2)))
       }
    }
@@ -191,7 +192,7 @@ object MollyCollectionTest extends IOSuite with TestContainerForAll[IO] with Mol
             coll    <- db.getCollection("deleteMany")
             _       <- coll.insertMany(Seq(doc1, doc2, doc3))
             _       <- coll.deleteMany(Filters.in("foo", "bar", "baz"))
-            results <- coll.find().list
+            results <- coll.find().list()
          } yield expect(results.size == 1)
             .and(expect(results.contains(doc3)))
       }
@@ -206,7 +207,7 @@ object MollyCollectionTest extends IOSuite with TestContainerForAll[IO] with Mol
             coll    <- db.getCollection("deleteOne")
             _       <- coll.insertMany(Seq(doc1, doc2))
             _       <- coll.deleteOne(Filters.eq("foo", "bar"))
-            results <- coll.find().list
+            results <- coll.find().list()
          } yield expect(results.size == 1)
             .and(expect(results.contains(doc2)))
       }
@@ -231,7 +232,7 @@ object MollyCollectionTest extends IOSuite with TestContainerForAll[IO] with Mol
          for {
             db      <- client.getDatabase("test")
             coll    <- db.getCollection("find1")
-            results <- coll.find().list
+            results <- coll.find().list()
          } yield expect(results.isEmpty)
       }
    }
@@ -245,7 +246,7 @@ object MollyCollectionTest extends IOSuite with TestContainerForAll[IO] with Mol
             db      <- client.getDatabase("test")
             coll    <- db.getCollection("find2")
             _       <- coll.insertMany(Seq(doc1, doc2, doc3))
-            results <- coll.find().list
+            results <- coll.find().list()
          } yield expect(results.size == 3)
             .and(expect(results.contains(doc1)))
             .and(expect(results.contains(doc2)))
@@ -295,7 +296,7 @@ object MollyCollectionTest extends IOSuite with TestContainerForAll[IO] with Mol
             db      <- client.getDatabase("test")
             coll    <- db.getCollection("find5")
             _       <- coll.insertMany(Seq(doc1, doc2, doc3))
-            results <- coll.find(Filters.gt("x", 25)).list
+            results <- coll.find(Filters.gt("x", 25)).list()
          } yield expect(results.size == 2)
             .and(expect(results.contains(doc1)))
             .and(expect(results.contains(doc3)))
@@ -311,7 +312,7 @@ object MollyCollectionTest extends IOSuite with TestContainerForAll[IO] with Mol
             db      <- client.getDatabase("test")
             coll    <- db.getCollection("find6")
             _       <- coll.insertMany(Seq(doc1, doc2, doc3))
-            results <- coll.find().filter(Filters.gt("x", 25)).list
+            results <- coll.find().filter(Filters.gt("x", 25)).list()
          } yield expect(results.size == 2)
             .and(expect(results.contains(doc1)))
             .and(expect(results.contains(doc3)))
@@ -327,7 +328,7 @@ object MollyCollectionTest extends IOSuite with TestContainerForAll[IO] with Mol
             coll    <- db.getCollection("findOneAndDelete1")
             _       <- coll.insertMany(Seq(doc1, doc2))
             resDoc  <- coll.findOneAndDelete(Filters.eq("_id", 2))
-            resColl <- coll.find().list
+            resColl <- coll.find().list()
          } yield expect(resDoc == Some(doc2))
             .and(expect(resColl.size == 1))
             .and(expect(resColl.contains(doc1)))
@@ -343,7 +344,7 @@ object MollyCollectionTest extends IOSuite with TestContainerForAll[IO] with Mol
             coll    <- db.getCollection("findOneAndDelete2")
             _       <- coll.insertMany(Seq(doc1, doc2))
             resDoc  <- coll.findOneAndDelete(Filters.eq("_id", 3))
-            resColl <- coll.find().list
+            resColl <- coll.find().list()
          } yield expect(resDoc == None)
             .and(expect(resColl.size == 2))
             .and(expect(resColl.contains(doc1)))
@@ -361,7 +362,7 @@ object MollyCollectionTest extends IOSuite with TestContainerForAll[IO] with Mol
             coll    <- db.getCollection("findOneAndReplace")
             _       <- coll.insertMany(Seq(doc1, doc2))
             resDoc  <- coll.findOneAndReplace(Filters.eq("_id", 2), doc2a)
-            resColl <- coll.find().list
+            resColl <- coll.find().list()
          } yield expect(resDoc == Some(doc2))
             .and(expect(resColl.size == 2))
             .and(expect(resColl.contains(doc1)))
@@ -379,7 +380,7 @@ object MollyCollectionTest extends IOSuite with TestContainerForAll[IO] with Mol
             coll    <- db.getCollection("findOneAndReplace1")
             _       <- coll.insertMany(Seq(doc1, doc2))
             resDoc  <- coll.findOneAndReplace(Filters.eq("_id", 3), doc3)
-            resColl <- coll.find().list
+            resColl <- coll.find().list()
          } yield expect(resDoc == None)
             .and(expect(resColl.size == 2))
             .and(expect(resColl.contains(doc1)))
@@ -402,7 +403,7 @@ object MollyCollectionTest extends IOSuite with TestContainerForAll[IO] with Mol
                   doc2,
                   FindOneAndReplaceOptions().upsert(true)
                )
-               resColl <- coll.find().list
+               resColl <- coll.find().list()
             } yield expect(resDoc == None)
                .and(expect(resColl.size == 2))
                .and(expect(resColl.contains(doc1)))
@@ -424,7 +425,7 @@ object MollyCollectionTest extends IOSuite with TestContainerForAll[IO] with Mol
                   doc2,
                   FindOneAndReplaceOptions().upsert(false)
                )
-               resColl <- coll.find().list
+               resColl <- coll.find().list()
             } yield expect(resDoc == None)
                .and(expect(resColl.size == 1))
                .and(expect(resColl.contains(doc1)))
@@ -442,7 +443,7 @@ object MollyCollectionTest extends IOSuite with TestContainerForAll[IO] with Mol
             coll    <- db.getCollection("findOneAndUpdate1")
             _       <- coll.insertMany(Seq(doc1, doc2))
             resDoc  <- coll.findOneAndUpdate(Filters.eq("_id", 2), Updates.set("foo", "yoo"))
-            resColl <- coll.find().list
+            resColl <- coll.find().list()
          } yield expect(resDoc == Some(doc2))
             .and(expect(resColl.size == 2))
             .and(expect(resColl.contains(doc1)))
@@ -460,7 +461,7 @@ object MollyCollectionTest extends IOSuite with TestContainerForAll[IO] with Mol
             coll    <- db.getCollection("findOneAndUpdate2")
             _       <- coll.insertMany(Seq(doc1, doc2))
             resDoc  <- coll.findOneAndUpdate(Filters.eq("_id", 3), Updates.set("foo", "yoo"))
-            resColl <- coll.find().list
+            resColl <- coll.find().list()
          } yield expect(resDoc == None)
             .and(expect(resColl.size == 2))
             .and(expect(resColl.contains(doc1)))
@@ -478,7 +479,7 @@ object MollyCollectionTest extends IOSuite with TestContainerForAll[IO] with Mol
             db      <- client.getDatabase("test")
             coll    <- db.getCollection("insertMany")
             _       <- coll.insertMany(Seq(doc1, doc2, doc3))
-            results <- coll.find().list
+            results <- coll.find().list()
          } yield expect(results.size == 3)
             .and(expect(results.contains(doc1)))
             .and(expect(results.contains(doc2)))
@@ -493,7 +494,7 @@ object MollyCollectionTest extends IOSuite with TestContainerForAll[IO] with Mol
             db      <- client.getDatabase("test")
             coll    <- db.getCollection("insertOne")
             _       <- coll.insertOne(doc)
-            results <- coll.find().list
+            results <- coll.find().list()
          } yield expect(results.size == 1)
             .and(expect(results.contains(doc)))
       }
@@ -509,7 +510,7 @@ object MollyCollectionTest extends IOSuite with TestContainerForAll[IO] with Mol
             coll    <- db.getCollection("replaceOne1")
             _       <- coll.insertMany(Seq(doc1, doc2))
             res     <- coll.replaceOne(Filters.eq("_id", 2), doc2a)
-            results <- coll.find().list
+            results <- coll.find().list()
          } yield expect(results.size == 2)
             .and(expect(results.contains(doc1)))
             .and(expect(!results.contains(doc2)))
@@ -526,7 +527,7 @@ object MollyCollectionTest extends IOSuite with TestContainerForAll[IO] with Mol
             coll    <- db.getCollection("replaceOne2")
             _       <- coll.insertMany(Seq(doc1))
             res     <- coll.replaceOne(Filters.eq("_id", 2), doc2, ReplaceOptions().upsert(true))
-            results <- coll.find().list
+            results <- coll.find().list()
          } yield expect(results.size == 2)
             .and(expect(results.contains(doc1)))
             .and(expect(results.contains(doc2)))
@@ -542,7 +543,7 @@ object MollyCollectionTest extends IOSuite with TestContainerForAll[IO] with Mol
             coll    <- db.getCollection("replaceOne3")
             _       <- coll.insertMany(Seq(doc1))
             res     <- coll.replaceOne(Filters.eq("_id", 2), doc2, ReplaceOptions().upsert(false))
-            results <- coll.find().list
+            results <- coll.find().list()
          } yield expect(results.size == 1)
             .and(expect(results.contains(doc1)))
             .and(expect(!results.contains(doc2)))
@@ -561,7 +562,7 @@ object MollyCollectionTest extends IOSuite with TestContainerForAll[IO] with Mol
             coll    <- db.getCollection("updateMany")
             _       <- coll.insertMany(Seq(doc1, doc2, doc3))
             res     <- coll.updateMany(Filters.in("_id", 2, 3), Updates.inc("x", 5))
-            results <- coll.find().list
+            results <- coll.find().list()
          } yield expect(results.size == 3)
             .and(expect(results.contains(doc1)))
             .and(expect(!results.contains(doc2)))
@@ -582,7 +583,7 @@ object MollyCollectionTest extends IOSuite with TestContainerForAll[IO] with Mol
             coll    <- db.getCollection("updateOne")
             _       <- coll.insertMany(Seq(doc1, doc2, doc3))
             res     <- coll.updateOne(Filters.eq("_id", 2), Updates.inc("x", 4))
-            results <- coll.find().list
+            results <- coll.find().list()
          } yield expect(results.size == 3)
             .and(expect(results.contains(doc1)))
             .and(expect(!results.contains(doc2)))
@@ -602,7 +603,7 @@ object MollyCollectionTest extends IOSuite with TestContainerForAll[IO] with Mol
             coll    <- db.getCollection("updateOne2")
             _       <- coll.insertMany(Seq(doc1, doc2, doc3))
             _       <- coll.updateOne(Filters.eq("_id", 4), Updates.inc("x", 1024), UpdateOptions().upsert(true))
-            results <- coll.find().list
+            results <- coll.find().list()
          } yield expect(results.size == 4)
             .and(expect(results.contains(doc1)))
             .and(expect(results.contains(doc2)))
@@ -616,7 +617,8 @@ object MollyCollectionTest extends IOSuite with TestContainerForAll[IO] with Mol
          val doc1 = new BsonDocument("_id", new BsonInt32(1)).append("x", new BsonInt32(47))
          val doc2 = new BsonDocument("_id", new BsonInt32(2)).append("x", new BsonInt32(20))
          val doc3 = new BsonDocument("_id", new BsonInt32(3)).append("x", new BsonInt32(99))
-         def runChangeStream(coll: MollyCollection[IO]) = coll.watch().stream.take(3).compile.toList
+         def runChangeStream(coll: BsonDocumentCollection[IO]) =
+            coll.watch().stream(bufferSize = 1).take(3).compile.toList
          for {
             db     <- client.getDatabase("test")
             coll   <- db.getCollection("watch1")
@@ -634,8 +636,9 @@ object MollyCollectionTest extends IOSuite with TestContainerForAll[IO] with Mol
          val doc1 = new BsonDocument("_id", new BsonInt32(1)).append("x", new BsonInt32(47))
          val doc2 = new BsonDocument("_id", new BsonInt32(2)).append("x", new BsonInt32(20))
          val doc3 = new BsonDocument("_id", new BsonInt32(3)).append("x", new BsonInt32(99))
-         def runChangeStream(coll: MollyCollection[IO]) = coll.watch().stream.take(4).compile.toList
-         def insertAndUpdate(coll: MollyCollection[IO]) =
+         def runChangeStream(coll: BsonDocumentCollection[IO]) =
+            coll.watch().stream(bufferSize = 1).take(4).compile.toList
+         def insertAndUpdate(coll: BsonDocumentCollection[IO]) =
             coll.insertMany(Seq(doc1, doc2, doc3)) >> coll.updateOne(Filters.eq("_id", 2), Updates.set("x", 23))
          for {
             db     <- client.getDatabase("test")

--- a/molly-medeia/src/main/scala/molly/medeia/MedeiaCodec.scala
+++ b/molly-medeia/src/main/scala/molly/medeia/MedeiaCodec.scala
@@ -1,0 +1,27 @@
+package molly.medeia
+
+import cats.data.EitherNec
+import cats.effect.kernel.Async
+import cats.syntax.functor.*
+import cats.syntax.monadError.*
+import medeia.codec.BsonDocumentCodec
+import medeia.decoder.BsonDecoderError
+import molly.core.MollyCodec
+import org.bson.BsonDocument
+
+/** An implementation of [[molly.core.MollyCodec]] that uses to [[https://github.com/medeia/medeia Medeia]] for decoding
+  * and encoding.
+  */
+object codec {
+
+   implicit def instance[F[_]: Async, A: BsonDocumentCodec]: MollyCodec[F, A] = new MollyCodec[F, A] {
+
+      override def decode(doc: BsonDocument): F[A] =
+         Async[F].delay(BsonDocumentCodec[A].decode(doc)).map(summerizeErrors).rethrow
+
+      override def encode(obj: A): F[BsonDocument] = Async[F].delay(BsonDocumentCodec[A].encode(obj))
+
+      private def summerizeErrors(errorChain: EitherNec[BsonDecoderError, A]): Either[BsonDecoderError, A] =
+         errorChain.left.map(_.head)
+   }
+}

--- a/molly-medeia/src/test/scala/molly/medeia/TypedMollyCollectionTest.scala
+++ b/molly-medeia/src/test/scala/molly/medeia/TypedMollyCollectionTest.scala
@@ -1,0 +1,416 @@
+package molly.medeia
+
+import cats.effect.IO
+import com.dimafeng.testcontainers.MongoDBContainer
+import com.mongodb.client.model.Filters
+import com.mongodb.client.model.Updates
+import com.mongodb.client.model.changestream.FullDocument
+import medeia.codec.*
+import molly.core.MollyClient
+import molly.core.MollyCollection
+import molly.core.MollyTestSupport
+import molly.core.TestContainerForAll
+import molly.core.model.FindOneAndReplaceOptions
+import molly.core.model.ReplaceOptions
+import org.testcontainers.utility.DockerImageName
+import weaver.IOSuite
+
+object TypedMollyCollectionTest extends IOSuite with TestContainerForAll[IO] with MollyTestSupport {
+
+   case class City(name: String, state: String, area: Double, postalCodes: List[String])
+
+   implicit val cityCodec: BsonDocumentCodec[City] = BsonDocumentCodec.derived
+
+   import molly.medeia.codec.*
+
+   val trier = City(
+      name = "Trier",
+      state = "Rhineland-Palatinate",
+      area = 117.06,
+      postalCodes = List("54290", "54292", "54293", "54294", "54295", "54296")
+   )
+
+   val ludwigslust =
+      City(name = "Ludwigslust", state = "Mecklenburg-Vorpommern", area = 78.3, postalCodes = List("19288"))
+
+   val flensburg = City(
+      name = "Flensburg",
+      state = "Schleswig-Holstein",
+      area = 56.73,
+      postalCodes = List("24937", "24938", "24939", "24940", "24941", "24942", "24943", "24944")
+   )
+
+   override val containerDef: MongoDBContainer.Def = MongoDBContainer.Def(DockerImageName.parse("mongo:latest"))
+
+   test("deleteMany: delete given documents from collection") { containers =>
+      withClient(containers) { (client: MollyClient[IO]) =>
+         for {
+            db      <- client.getDatabase("test")
+            coll    <- db.getTypedCollection[City]("deleteMany")
+            _       <- coll.insertMany(Seq(trier, ludwigslust, flensburg))
+            _       <- coll.deleteMany(Filters.in("name", "Trier", "Flensburg"))
+            results <- coll.find().list()
+         } yield expect(results.size == 1)
+            .and(expect(results.contains(ludwigslust)))
+      }
+   }
+
+   test("deleteOne: delete one document from collection") { containers =>
+      withClient(containers) { (client: MollyClient[IO]) =>
+         for {
+            db      <- client.getDatabase("test")
+            coll    <- db.getTypedCollection[City]("deleteOne")
+            _       <- coll.insertMany(Seq(trier, ludwigslust))
+            _       <- coll.deleteOne(Filters.eq("name", "Trier"))
+            results <- coll.find().list()
+         } yield expect(results.size == 1)
+            .and(expect(results.contains(ludwigslust)))
+      }
+   }
+
+   test("find: return all documents from collection") { containers =>
+      withClient(containers) { (client: MollyClient[IO]) =>
+         for {
+            db      <- client.getDatabase("test")
+            coll    <- db.getTypedCollection[City]("find2")
+            _       <- coll.insertMany(Seq(trier, ludwigslust, flensburg))
+            results <- coll.find().list()
+         } yield expect(results.size == 3)
+            .and(expect(results.contains(trier)))
+            .and(expect(results.contains(ludwigslust)))
+            .and(expect(results.contains(flensburg)))
+      }
+   }
+
+   test("find first: return first found document from collection") { containers =>
+      withClient(containers) { (client: MollyClient[IO]) =>
+         for {
+            db     <- client.getDatabase("test")
+            coll   <- db.getTypedCollection[City]("find3")
+            _      <- coll.insertMany(Seq(trier, ludwigslust, flensburg))
+            result <- coll.find().first
+         } yield expect(result.isDefined)
+            .and(
+               expect(result.contains(trier))
+                  .or(expect(result.contains(ludwigslust)))
+                  .or(expect(result.contains(flensburg)))
+            )
+      }
+   }
+
+   test("find first: return no document when there is no match") { containers =>
+      withClient(containers) { (client: MollyClient[IO]) =>
+         for {
+            db     <- client.getDatabase("test")
+            coll   <- db.getTypedCollection[City]("find4")
+            _      <- coll.insertMany(Seq(trier, ludwigslust, flensburg))
+            result <- coll.find(Filters.eq("name", "Bielefeld")).first
+         } yield expect(result.isEmpty)
+      }
+   }
+
+   test("find: return all documents matching the given filter") { containers =>
+      withClient(containers) { (client: MollyClient[IO]) =>
+         for {
+            db      <- client.getDatabase("test")
+            coll    <- db.getTypedCollection[City]("find5")
+            _       <- coll.insertMany(Seq(trier, ludwigslust, flensburg))
+            results <- coll.find(Filters.gt("area", 70)).list()
+         } yield expect(results.size == 2)
+            .and(expect(results.contains(trier)))
+            .and(expect(results.contains(ludwigslust)))
+      }
+   }
+
+   test("find: return all documents matching the given chained filter") { containers =>
+      withClient(containers) { (client: MollyClient[IO]) =>
+         for {
+            db      <- client.getDatabase("test")
+            coll    <- db.getTypedCollection[City]("find6")
+            _       <- coll.insertMany(Seq(trier, ludwigslust, flensburg))
+            results <- coll.find().filter(Filters.gt("area", 70)).list()
+         } yield expect(results.size == 2)
+            .and(expect(results.contains(trier)))
+            .and(expect(results.contains(ludwigslust)))
+      }
+   }
+
+   test("findOneAndDelete: return one document and delete it from collection") { containers =>
+      withClient(containers) { (client: MollyClient[IO]) =>
+         for {
+            db      <- client.getDatabase("test")
+            coll    <- db.getTypedCollection[City]("findOneAndDelete1")
+            _       <- coll.insertMany(Seq(trier, ludwigslust))
+            resDoc  <- coll.findOneAndDelete(Filters.eq("name", "Trier"))
+            resColl <- coll.find().list()
+         } yield expect(resDoc == Some(trier))
+            .and(expect(resColl.size == 1))
+            .and(expect(resColl.contains(ludwigslust)))
+      }
+   }
+
+   test("findOneAndDelete: return and delete nothing if nothing matches the given filter") { containers =>
+      withClient(containers) { (client: MollyClient[IO]) =>
+         for {
+            db      <- client.getDatabase("test")
+            coll    <- db.getTypedCollection[City]("findOneAndDelete2")
+            _       <- coll.insertMany(Seq(trier, ludwigslust))
+            resDoc  <- coll.findOneAndDelete(Filters.eq("name", "Bielefeld"))
+            resColl <- coll.find().list()
+         } yield expect(resDoc == None)
+            .and(expect(resColl.size == 2))
+            .and(expect(resColl.contains(trier)))
+            .and(expect(resColl.contains(ludwigslust)))
+      }
+   }
+
+   test("findOneAndReplace: return one document and replace it in collection") { containers =>
+      withClient(containers) { (client: MollyClient[IO]) =>
+         val largerLudwigslust = ludwigslust.copy(area = 100)
+         for {
+            db      <- client.getDatabase("test")
+            coll    <- db.getTypedCollection[City]("findOneAndReplace")
+            _       <- coll.insertMany(Seq(trier, ludwigslust))
+            resDoc  <- coll.findOneAndReplace(Filters.eq("name", "Ludwigslust"), largerLudwigslust)
+            resColl <- coll.find().list()
+         } yield expect(resDoc == Some(ludwigslust))
+            .and(expect(resColl.size == 2))
+            .and(expect(resColl.contains(trier)))
+            .and(expect(resColl.contains(largerLudwigslust)))
+      }
+   }
+
+   test("findOneAndReplace: return and replace nothing if nothing matches the given filter") { containers =>
+      withClient(containers) { (client: MollyClient[IO]) =>
+         for {
+            db      <- client.getDatabase("test")
+            coll    <- db.getTypedCollection[City]("findOneAndReplace1")
+            _       <- coll.insertMany(Seq(trier, ludwigslust))
+            resDoc  <- coll.findOneAndReplace(Filters.eq("name", "Flensburg"), flensburg)
+            resColl <- coll.find().list()
+         } yield expect(resDoc == None)
+            .and(expect(resColl.size == 2))
+            .and(expect(resColl.contains(trier)))
+            .and(expect(resColl.contains(ludwigslust)))
+            .and(expect(!resColl.contains(flensburg)))
+      }
+   }
+
+   test("findOneAndReplace: return one document and replace it in collection - insert if it doesn't exist") {
+      containers =>
+         withClient(containers) { (client: MollyClient[IO]) =>
+            for {
+               db   <- client.getDatabase("test")
+               coll <- db.getTypedCollection[City]("findOneAndReplace2")
+               _    <- coll.insertOne(trier)
+               resDoc <- coll.findOneAndReplace(
+                  Filters.eq("name", "Ludwigslust"),
+                  ludwigslust,
+                  FindOneAndReplaceOptions().upsert(true)
+               )
+               resColl <- coll.find().list()
+            } yield expect(resDoc == None)
+               .and(expect(resColl.size == 2))
+               .and(expect(resColl.contains(trier)))
+               .and(expect(resColl.contains(ludwigslust)))
+         }
+   }
+
+   test("findOneAndReplace: return one document and replace it in collection - do not insert if it doesn't exist") {
+      containers =>
+         withClient(containers) { (client: MollyClient[IO]) =>
+            for {
+               db   <- client.getDatabase("test")
+               coll <- db.getTypedCollection[City]("findOneAndReplace3")
+               _    <- coll.insertOne(trier)
+               resDoc <- coll.findOneAndReplace(
+                  Filters.eq("name", "Ludwigslust"),
+                  ludwigslust,
+                  FindOneAndReplaceOptions().upsert(false)
+               )
+               resColl <- coll.find().list()
+            } yield expect(resDoc == None)
+               .and(expect(resColl.size == 1))
+               .and(expect(resColl.contains(trier)))
+               .and(expect(!resColl.contains(ludwigslust)))
+         }
+   }
+
+   test("findOneAndUpdate: return one document and update it in collection") { containers =>
+      withClient(containers) { (client: MollyClient[IO]) =>
+         val largerFlensburg = flensburg.copy(area = 105.5)
+         for {
+            db      <- client.getDatabase("test")
+            coll    <- db.getTypedCollection[City]("findOneAndUpdate1")
+            _       <- coll.insertMany(Seq(trier, flensburg))
+            resDoc  <- coll.findOneAndUpdate(Filters.eq("name", "Flensburg"), Updates.set("area", 105.5))
+            resColl <- coll.find().list()
+         } yield expect(resDoc == Some(flensburg))
+            .and(expect(resColl.size == 2))
+            .and(expect(resColl.contains(trier)))
+            .and(expect(resColl.contains(largerFlensburg)))
+      }
+   }
+
+   test("findOneAndUpdate: return and update nothing if nothing matches the given filter") { containers =>
+      withClient(containers) { (client: MollyClient[IO]) =>
+         for {
+            db      <- client.getDatabase("test")
+            coll    <- db.getTypedCollection[City]("findOneAndUpdate2")
+            _       <- coll.insertMany(Seq(trier, ludwigslust))
+            resDoc  <- coll.findOneAndUpdate(Filters.eq("name", "Flensburg"), Updates.set("area", 100))
+            resColl <- coll.find().list()
+         } yield expect(resDoc == None)
+            .and(expect(resColl.size == 2))
+            .and(expect(resColl.contains(trier)))
+            .and(expect(resColl.contains(ludwigslust)))
+            .and(expect(!resColl.contains(flensburg)))
+      }
+   }
+
+   test("insertMany: write given documents to collection") { containers =>
+      withClient(containers) { (client: MollyClient[IO]) =>
+         for {
+            db      <- client.getDatabase("test")
+            coll    <- db.getTypedCollection[City]("insertMany")
+            _       <- coll.insertMany(Seq(trier, ludwigslust, flensburg))
+            results <- coll.find().list()
+         } yield expect(results.size == 3)
+            .and(expect(results.contains(trier)))
+            .and(expect(results.contains(ludwigslust)))
+            .and(expect(results.contains(flensburg)))
+      }
+   }
+
+   test("insertOne: write one document to collection") { containers =>
+      withClient(containers) { (client: MollyClient[IO]) =>
+         for {
+            db      <- client.getDatabase("test")
+            coll    <- db.getTypedCollection[City]("insertOne")
+            _       <- coll.insertOne(trier)
+            results <- coll.find().list()
+         } yield expect(results.size == 1)
+            .and(expect(results.contains(trier)))
+      }
+   }
+
+   test("replaceOne: replace one document in collection") { containers =>
+      withClient(containers) { (client: MollyClient[IO]) =>
+         val largerLudwigslust = ludwigslust.copy(area = 100)
+         for {
+            db      <- client.getDatabase("test")
+            coll    <- db.getTypedCollection[City]("replaceOne1")
+            _       <- coll.insertMany(Seq(trier, ludwigslust))
+            res     <- coll.replaceOne(Filters.eq("name", "Ludwigslust"), largerLudwigslust)
+            results <- coll.find().list()
+         } yield expect(results.size == 2)
+            .and(expect(results.contains(trier)))
+            .and(expect(!results.contains(ludwigslust)))
+            .and(expect(results.contains(largerLudwigslust)))
+      }
+   }
+
+   test("replaceOne: replace one document in collection - insert if it doesn't exist") { containers =>
+      withClient(containers) { (client: MollyClient[IO]) =>
+         for {
+            db      <- client.getDatabase("test")
+            coll    <- db.getTypedCollection[City]("replaceOne2")
+            _       <- coll.insertMany(Seq(trier))
+            res     <- coll.replaceOne(Filters.eq("name", "Ludwigslust"), ludwigslust, ReplaceOptions().upsert(true))
+            results <- coll.find().list()
+         } yield expect(results.size == 2)
+            .and(expect(results.contains(trier)))
+            .and(expect(results.contains(ludwigslust)))
+      }
+   }
+
+   test("replaceOne: replace one document in collection - do not insert if it doesn't exist") { containers =>
+      withClient(containers) { (client: MollyClient[IO]) =>
+         for {
+            db   <- client.getDatabase("test")
+            coll <- db.getTypedCollection[City]("replaceOne3")
+            _    <- coll.insertMany(Seq(trier))
+            res  <- coll.replaceOne(Filters.eq("name", ludwigslust.name), ludwigslust, ReplaceOptions().upsert(false))
+            results <- coll.find().list()
+         } yield expect(results.size == 1)
+            .and(expect(results.contains(trier)))
+            .and(expect(!results.contains(ludwigslust)))
+      }
+   }
+
+   test("updateMany: update multiple documents in collection") { containers =>
+      withClient(containers) { (client: MollyClient[IO]) =>
+         val largerLudwigslust = ludwigslust.copy(area = 80.5)
+         val largerFlensburg = flensburg.copy(area = 80.5)
+         for {
+            db      <- client.getDatabase("test")
+            coll    <- db.getTypedCollection[City]("updateMany")
+            _       <- coll.insertMany(Seq(trier, ludwigslust, flensburg))
+            res     <- coll.updateMany(Filters.in("name", "Ludwigslust", "Flensburg"), Updates.set("area", 80.5))
+            results <- coll.find().list()
+         } yield expect(results.size == 3)
+            .and(expect(results.contains(trier)))
+            .and(expect(!results.contains(ludwigslust)))
+            .and(expect(results.contains(largerLudwigslust)))
+            .and(expect(!results.contains(flensburg)))
+            .and(expect(results.contains(largerFlensburg)))
+      }
+   }
+
+   test("updateOne: update one document in collection") { containers =>
+      withClient(containers) { (client: MollyClient[IO]) =>
+         val largerLudwigslust = ludwigslust.copy(area = 80.5)
+         for {
+            db      <- client.getDatabase("test")
+            coll    <- db.getTypedCollection[City]("updateOne")
+            _       <- coll.insertMany(Seq(trier, ludwigslust, flensburg))
+            res     <- coll.updateOne(Filters.eq("name", "Ludwigslust"), Updates.set("area", 80.5))
+            results <- coll.find().list()
+         } yield expect(results.size == 3)
+            .and(expect(results.contains(trier)))
+            .and(expect(!results.contains(ludwigslust)))
+            .and(expect(results.contains(largerLudwigslust)))
+            .and(expect(results.contains(flensburg)))
+      }
+   }
+
+   test("watch: return one change per inserted document") { containers =>
+      withClient(containers) { (client: MollyClient[IO]) =>
+         def runChangeStream(coll: MollyCollection[IO, City]) =
+            coll.watch().stream(bufferSize = 1).take(3).compile.toList
+         for {
+            db     <- client.getDatabase("test")
+            coll   <- db.getTypedCollection[City]("watch1")
+            csDocs <- runChangeStream(coll).both(coll.insertMany(Seq(trier, ludwigslust, flensburg))).map(_._1)
+         } yield expect(csDocs.size == 3)
+            .and(expect(csDocs.exists(_.getFullDocument == trier)))
+            .and(expect(csDocs.exists(_.getFullDocument == ludwigslust)))
+            .and(expect(csDocs.exists(_.getFullDocument == flensburg)))
+            .and(expect(csDocs.forall(_.getOperationTypeString() == "insert")))
+      }
+   }
+
+   test("watch: return different changes") { containers =>
+      withClient(containers) { (client: MollyClient[IO]) =>
+         val largerLudwigslust = ludwigslust.copy(area = 100.3)
+         def runChangeStream(coll: MollyCollection[IO, City]) =
+            coll.watch().fullDocument(FullDocument.UPDATE_LOOKUP).stream(bufferSize = 1).take(4).compile.toList
+         def insertAndUpdate(coll: MollyCollection[IO, City]) =
+            coll.insertMany(Seq(trier, ludwigslust, flensburg)) >> coll.updateOne(
+               Filters.eq("name", "Ludwigslust"),
+               Updates.set("area", 100.3)
+            )
+         for {
+            db     <- client.getDatabase("test")
+            coll   <- db.getTypedCollection[City]("watch2")
+            csDocs <- runChangeStream(coll).both(insertAndUpdate(coll)).map(_._1)
+         } yield expect(csDocs.size == 4)
+            .and(expect(csDocs.exists(_.getFullDocument == trier)))
+            .and(expect(csDocs.exists(_.getFullDocument == ludwigslust)))
+            .and(expect(csDocs.exists(_.getFullDocument == flensburg)))
+            .and(expect(csDocs.exists(_.getFullDocument == largerLudwigslust)))
+            .and(expect(csDocs.take(3).forall(_.getOperationTypeString() == "insert")))
+            .and(expect(csDocs.last.getOperationTypeString() == "update"))
+      }
+   }
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,3 @@
-resolvers += Resolver.sonatypeRepo("snapshots")
-
 addSbtPlugin("ch.epfl.scala"    % "sbt-scalafix"              % "0.11.1")
 addSbtPlugin("com.github.cb372" % "sbt-explicit-dependencies" % "0.3.1")
 addSbtPlugin("com.github.sbt"   % "sbt-ci-release"            % "1.5.12")


### PR DESCRIPTION
* Introduce MollyCodec in core
* Let MollyCollection utitize MollyCodec for any meaningful operation
* Provide identity mapping in core
* Add module for encoding/decoding datatypes using Medeia